### PR TITLE
Simplify API for streaming and fix unmatchable bug

### DIFF
--- a/__tests__/__snapshots__/react.integration.spec.tsx.snap
+++ b/__tests__/__snapshots__/react.integration.spec.tsx.snap
@@ -14,8 +14,8 @@ input { display: none; }
 `;
 
 exports[`React css stream React.renderToStream 1`] = `
-"input { color: rightInput; }
-<style type=\\"text/css\\" data-used-styles=\\"file1,file2\\">.a,
+"<style type=\\"text/css\\" data-used-styles=\\"true\\">input { color: rightInput; }
+</style><style type=\\"text/css\\" data-used-styles=\\"file1,file2\\">.a,
 .b { color: rightColor; }
 .c,
 .d { marker: blueMark; }

--- a/__tests__/css-stream.spec.tsx
+++ b/__tests__/css-stream.spec.tsx
@@ -32,16 +32,7 @@ describe('css stream', () => {
   });
 
   it('React.renderToStream', async () => {
-    const styles = {};
-    const cssStream = createStyleStream(createLookup({
-      a: ['file1'],
-      b: ['file1', 'file2'],
-      zz: ['file3'],
-      notused: ['file4']
-    }), style => {
-      styles[style] = (styles[style] || 0) + 1;
-    });
-    const output = renderToStaticNodeStream(
+    const reactStream = renderToStaticNodeStream(
       <div>
         <div className="a">
           <div className="a b c">
@@ -55,6 +46,17 @@ describe('css stream', () => {
       </div>
     );
 
+    const styles = {};
+    const cssStream = createStyleStream(reactStream, createLookup({
+      a: ['file1'],
+      b: ['file1', 'file2'],
+      zz: ['file3'],
+      notused: ['file4']
+    }), style => {
+      styles[style] = (styles[style] || 0) + 1;
+    });
+
+
     const streamString = async (readStream) => {
       const result = [];
       for await (const chunk of readStream) {
@@ -64,8 +66,8 @@ describe('css stream', () => {
     };
 
     const [tr, base] = await Promise.all([
-      streamString(output.pipe(cssStream)),
-      streamString(output)
+      streamString(cssStream),
+      streamString(reactStream)
     ]);
 
     expect(base).toEqual(tr);

--- a/__tests__/react-css-stream.spec.tsx
+++ b/__tests__/react-css-stream.spec.tsx
@@ -33,16 +33,7 @@ describe('React css stream', () => {
   });
 
   it('React.renderToStream', async () => {
-    const styles = {};
-    const cssStream = createStyleStream(createLookup({
-      a: ['file1'],
-      b: ['file1', 'file2'],
-      zz: ['file3'],
-      notused: ['file4']
-    }), style => {
-      styles[style] = (styles[style] || 0) + 1;
-    });
-    const output = renderToStaticNodeStream(
+    const reactStream = renderToStaticNodeStream(
       <div>
         <div className="a">
           <div className="a b c">
@@ -56,6 +47,17 @@ describe('React css stream', () => {
       </div>
     );
 
+    const styles = {};
+    const cssStream = createStyleStream(reactStream, createLookup({
+      a: ['file1'],
+      b: ['file1', 'file2'],
+      zz: ['file3'],
+      notused: ['file4']
+    }), style => {
+      styles[style] = (styles[style] || 0) + 1;
+    });
+
+
     const streamString = async (readStream) => {
       const result = [];
       for await (const chunk of readStream) {
@@ -65,8 +67,8 @@ describe('React css stream', () => {
     };
 
     const [tr, base] = await Promise.all([
-      streamString(output.pipe(cssStream)),
-      streamString(output)
+      streamString(cssStream),
+      streamString(reactStream)
     ]);
 
     expect(base).toEqual(tr);

--- a/__tests__/react.integration.spec.tsx
+++ b/__tests__/react.integration.spec.tsx
@@ -120,9 +120,7 @@ describe('React css stream', () => {
   enableReactOptimization();
 
   it('React.renderToStream', async () => {
-    const criticalStream = createCriticalStyleStream(lookup);
-    const cssStream = createStyleStream(lookup, createLink);
-    const output = renderToStaticNodeStream(
+    const reactStream = renderToStaticNodeStream(
       <div>
         <div className="a">
           <div className="a b c">
@@ -137,6 +135,10 @@ describe('React css stream', () => {
       </div>
     );
 
+    const criticalStream = createCriticalStyleStream(reactStream, lookup);
+    const cssStream = createStyleStream(reactStream, lookup, createLink);
+
+
     const streamString = async (readStream) => {
       const result = [];
       for await (const chunk of readStream) {
@@ -145,9 +147,9 @@ describe('React css stream', () => {
       return result.join('');
     };
 
-    const htmlCritical_a = streamString(output.pipe(criticalStream));
-    const htmlLink_a = streamString(output.pipe(cssStream));
-    const html_a = streamString(output);
+    const htmlCritical_a = streamString(criticalStream);
+    const htmlLink_a = streamString(cssStream);
+    const html_a = streamString(reactStream);
 
     const html = await html_a;
     const htmlCritical = await htmlCritical_a;

--- a/src/getCSS.ts
+++ b/src/getCSS.ts
@@ -106,8 +106,9 @@ export const extractAllUnmatchable = kashe((def: StyleDefinition): StyleChunk[] 
 ));
 
 export const extractAllUnmatchableAsString = kashe((def: StyleDefinition) => (
-  extractAllUnmatchable(def)
-    .reduce((acc, {css}) => acc + css, '')
+  wrapInStyle(
+    extractAllUnmatchable(def).reduce((acc, {css}) => acc + css, '')
+  )
 ));
 
 const criticalRulesToStyle = (styles: StyleChunk[], urlPrefix = ''): string => (


### PR DESCRIPTION
We can simplify API for users by hiding pipe inside of createStyleStream/createCriticalStyleStream. So users will just wrap React stream with our function. So the whole render process becomes simpler because we don't need multistream dep and also it's easier to catch errors because now we forward error from React stream.

I don't understand your idea with [block rendering](https://github.com/theKashey/used-styles/blob/e42867ac86d17e22609eee6ad55275446b723222/README.md#block-rendering) (I don't understand what headerStream stands for) so it's kinda hard to update usage in this block.

Also, I can make it with backward capability but not sure that it worth it.

And there is a problem with `extractAllUnmatchableAsString`. It didn't wrap css into style tag. I fixed it in this PR, but I can create another one for it.

![image](https://user-images.githubusercontent.com/5969049/76714037-e4eebc00-6735-11ea-8c2e-d49e5aa0381d.png)
