### PR TITLE
Correct selection hash

### DIFF
--- a/__tests__/extraction.spec.tsx
+++ b/__tests__/extraction.spec.tsx
@@ -1,0 +1,71 @@
+import { getCriticalRules, loadStyleDefinitions, StyleDefinition } from '../src';
+
+describe('extraction stories', () => {
+  it('handles duplicated selectors', async () => {
+    const styles: StyleDefinition = loadStyleDefinitions(
+      () => ['test.css'],
+      () => `
+.test {
+  display: inline-block;
+}
+
+.test {
+  padding: 10px;
+}
+
+.test:focus {
+  color: red;
+}
+
+.test:focus {
+  border: blue;
+}
+`
+    );
+    await styles;
+
+    const extracted = getCriticalRules('<div class="test">', styles);
+
+    expect(extracted).toMatchInlineSnapshot(`
+      "
+      /* test.css */
+      .test { display: inline-block; }
+      .test { padding: 10px; }
+      .test:focus { color: red; }
+      .test:focus { border: blue; }
+      "
+    `);
+  });
+
+  it('extract pseudo selectors', async () => {
+    const styles: StyleDefinition = loadStyleDefinitions(
+      () => ['test.css'],
+      () => `
+.test {
+  display: inline-block;
+}
+
+.test:not(.some) {
+  padding: 10px;
+}
+
+.test:focus,
+.test::hover {
+  padding: 10px;
+}
+`
+    );
+    await styles;
+
+    const extracted = getCriticalRules('<div class="test">', styles);
+
+    expect(extracted).toMatchInlineSnapshot(`
+      "
+      /* test.css */
+      .test { display: inline-block; }
+      .test:focus,
+      .test::hover { padding: 10px; }
+      "
+    `);
+  });
+});

--- a/__tests__/extraction.spec.tsx
+++ b/__tests__/extraction.spec.tsx
@@ -63,6 +63,7 @@ describe('extraction stories', () => {
       "
       /* test.css */
       .test { display: inline-block; }
+      .test:not(.some) { padding: 10px; }
       .test:focus,
       .test::hover { padding: 10px; }
       "

--- a/src/getCSS.ts
+++ b/src/getCSS.ts
@@ -195,6 +195,8 @@ export const getCriticalStyles = (
   def: StyleDefinition,
   filter: SelectionFilter = createUsedFilter()
 ): string => {
+  assertIsReady(def);
+
   return criticalRulesToStyle(
     [...extractAllUnmatchable(def, filter), ...getRawCriticalRules(html, def, filter)],
     def.urlPrefix

--- a/src/parser/toAst.ts
+++ b/src/parser/toAst.ts
@@ -32,10 +32,10 @@ const getBreak = (rule: string) => {
 
   return min ? min : rule.length;
 };
-//
-// const getBeforePostfix = (rule: string) => {
-//   return rule.substr(0,getBreak(rule)).trim();
-// };
+
+const getBeforePostfix = (rule: string) => {
+  return rule.substr(0, getBreak(rule)).trim();
+};
 
 const getPostfix = (rule: string) => {
   return rule.substr(getBreak(rule)).trim();
@@ -103,7 +103,7 @@ export const buildAst = (CSS: string, file = ''): SingleStyleAst => {
         const stand: StyleSelector = {
           media: getAtRule(rule),
           selector,
-          pieces: mapSelector(selector),
+          pieces: mapSelector(getBeforePostfix(selector)),
           postfix: getPostfix(selector),
           declaration: 0,
           hash: selector,

--- a/src/parser/toAst.ts
+++ b/src/parser/toAst.ts
@@ -32,6 +32,10 @@ const getBreak = (rule: string) => {
 
   return min ? min : rule.length;
 };
+//
+// const getBeforePostfix = (rule: string) => {
+//   return rule.substr(0,getBreak(rule)).trim();
+// };
 
 const getPostfix = (rule: string) => {
   return rule.substr(getBreak(rule)).trim();
@@ -126,7 +130,7 @@ export const buildAst = (CSS: string, file = ''): SingleStyleAst => {
         });
 
         stand.declaration = assignBody(delc, bodies).id;
-        stand.hash = `${selector}${hashBody(delc)}${hashString(stand.media.join())}`;
+        stand.hash = `${selector}${hashBody(delc)}${hashString(stand.postfix)}${hashString(stand.media.join())}`;
 
         selectors.push(stand);
       });

--- a/src/parser/toAst.ts
+++ b/src/parser/toAst.ts
@@ -100,7 +100,6 @@ export const buildAst = (CSS: string, file = ''): SingleStyleAst => {
           media: getAtRule(rule),
           selector,
           pieces: mapSelector(selector),
-          // pieces: mapSelector(getBeforePostfix(selector)),
           postfix: getPostfix(selector),
           declaration: 0,
           hash: selector,

--- a/src/parser/toAst.ts
+++ b/src/parser/toAst.ts
@@ -33,10 +33,6 @@ const getBreak = (rule: string) => {
   return min ? min : rule.length;
 };
 
-const getBeforePostfix = (rule: string) => {
-  return rule.substr(0, getBreak(rule)).trim();
-};
-
 const getPostfix = (rule: string) => {
   return rule.substr(getBreak(rule)).trim();
 };
@@ -103,7 +99,8 @@ export const buildAst = (CSS: string, file = ''): SingleStyleAst => {
         const stand: StyleSelector = {
           media: getAtRule(rule),
           selector,
-          pieces: mapSelector(getBeforePostfix(selector)),
+          pieces: mapSelector(selector),
+          // pieces: mapSelector(getBeforePostfix(selector)),
           postfix: getPostfix(selector),
           declaration: 0,
           hash: selector,

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -10,18 +10,20 @@ export const mapStyles = (styles: string) =>
       .match(/\.([^>~,+$:{\[\s]+)?/g) || []
   )
     // clean style name
-    .map(x => x.replace(/[\s,.>~+$]+/, ''))
-    .map(x => x.replace(/[.\s.:]+/, ''));
+    .map((x) => x.replace(/[\s,.>~+$]+/, ''))
+    .map((x) => x.replace(/[.\s.:]+/, ''));
 
 export const mapSelector = (selector: string) => {
+  // replace `something:not(.something)` to `something:not`
+  const cleanSelector = selector.replace(/\(([^)])*\)/, '');
   const ruleSelection =
     // anything like "style"
-    selector.match(/\.([^>~+$:{\[\s]+)?/g) || [];
+    cleanSelector.match(/\.([^>~+$:{\[\s]+)?/g) || [];
 
   ruleSelection.reverse();
 
   const effectiveMatcher: string = ruleSelection.find(classish) || '';
   const selectors = effectiveMatcher.match(/(\.[^.>~+,$:{\[\s]+)?/g);
 
-  return (selectors || []).map(x => x.replace(/[.\s.:]+/, '')).filter(Boolean);
+  return (selectors || []).map((x) => x.replace(/[.\s.:]+/, '')).filter(Boolean);
 };


### PR DESCRIPTION
#33 exposed an edge case for regular expression matching the wrong part of a string
- obvious fix (https://github.com/theKashey/used-styles/commit/68449e3b15b4041a1fc9d521e1900eef2f3d21db) broke many other cases
- use case-specific fix (https://github.com/theKashey/used-styles/commit/a8899eeb8ee7856ecbcf5528a7d207f71120baf0) seems to be fine