### PR TITLE
fix: add support for class names which are keys from object prototype

### DIFF
--- a/src/getCSS.ts
+++ b/src/getCSS.ts
@@ -34,9 +34,9 @@ export const astToUsedStyles = kashe((styles: string[], def: StyleDefinition) =>
     const classes = className.split(' ');
 
     classes.forEach((singleClass) => {
-      const files = lookup[singleClass];
+      if (lookup.hasOwnProperty(singleClass)) {
+        const files = lookup[singleClass];
 
-      if (files) {
         files.forEach((file) => {
           if (!fetches[file]) {
             fetches[file] = {};


### PR DESCRIPTION
This PR fixes an issue in `astToUsedStyles`, that would crash if it received a class name which also was a function in the Object.prototype eg. "toString".